### PR TITLE
다크 모드 기능 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,12 +3,32 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* 명시적 라이트 모드 */
+.light .shiki,
+.light .shiki span {
+  color: var(--shiki-light) !important;
+  background-color: var(--shiki-light-bg) !important;
+  font-style: var(--shiki-light-font-style) !important;
+  font-weight: var(--shiki-light-font-weight) !important;
+  text-decoration: var(--shiki-light-text-decoration) !important;
+}
+
+/* 명시적 다크 모드 */
+.dark .shiki,
+.dark .shiki span {
+  color: var(--shiki-dark) !important;
+  background-color: var(--shiki-dark-bg) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
+/* 시스템 설정 (JavaScript 로드 전) */
 @media (prefers-color-scheme: dark) {
   .shiki,
   .shiki span {
     color: var(--shiki-dark) !important;
     background-color: var(--shiki-dark-bg) !important;
-    /* Optional, if you also want font styles */
     font-style: var(--shiki-dark-font-style) !important;
     font-weight: var(--shiki-dark-font-weight) !important;
     text-decoration: var(--shiki-dark-text-decoration) !important;
@@ -36,6 +56,26 @@
       --color-primary: #2f81f7;
       --color-primary-hover: #1f6feb;
     }
+  }
+
+  :root.light {
+    --color-border: #d1d5db;
+    --color-text: #24292f;
+    --color-text-secondary: #57606a;
+    --color-bg: #ffffff;
+    --color-bg-secondary: #f6f8fa;
+    --color-primary: #0969da;
+    --color-primary-hover: #0860ca;
+  }
+
+  :root.dark {
+    --color-border: #30363d;
+    --color-text: #e6edf3;
+    --color-text-secondary: #8b949e;
+    --color-bg: #0d1117;
+    --color-bg-secondary: #161b22;
+    --color-primary: #2f81f7;
+    --color-primary-hover: #1f6feb;
   }
 
   * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { pretendard } from "./fonts";
 import "./globals.css";
 import Link from "next/link";
 import { Analytics } from "@vercel/analytics/next";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 export const metadata: Metadata = {
   title: "Dogma Blog",
@@ -18,19 +20,22 @@ export default function RootLayout({
     <html lang="ko">
       <head></head>
       <body className={`${pretendard.variable}`}>
-        <header className="bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)]">
-          <div className="container flex items-center h-16">
-            <h1 className="text-xl font-semibold">
-              <Link
-                href="/"
-                className="text-[var(--color-text)] hover:text-[var(--color-text)] no-underline hover:underline-0 cursor-pointer"
-              >
-                Dogma Blog
-              </Link>
-            </h1>
-          </div>
-        </header>
-        <main className="container py-6">{children}</main>
+        <ThemeProvider>
+          <header className="bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)]">
+            <div className="container flex items-center justify-between h-16">
+              <h1 className="text-xl font-semibold">
+                <Link
+                  href="/"
+                  className="text-[var(--color-text)] hover:text-[var(--color-text)] no-underline hover:underline-0 cursor-pointer"
+                >
+                  Dogma Blog
+                </Link>
+              </h1>
+              <ThemeToggle />
+            </div>
+          </header>
+          <main className="container py-6">{children}</main>
+        </ThemeProvider>
         <Analytics />
       </body>
     </html>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useTheme } from '@/contexts/ThemeContext'
+
+export function ThemeToggle() {
+  const { theme, setTheme, resolvedTheme } = useTheme()
+
+  const handleToggle = () => {
+    if (theme === 'system') {
+      setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+    } else {
+      setTheme(theme === 'dark' ? 'light' : 'dark')
+    }
+  }
+
+  const handleSystemMode = () => {
+    setTheme('system')
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={handleToggle}
+        className="p-2 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-800"
+        title={`현재: ${resolvedTheme === 'dark' ? '다크' : '라이트'} 모드`}
+      >
+        {resolvedTheme === 'dark' ? '🌙' : '☀️'}
+      </button>
+      
+      <button
+        onClick={handleSystemMode}
+        className={`p-2 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-800 ${
+          theme === 'system' ? 'bg-blue-100 dark:bg-blue-900' : ''
+        }`}
+        title="시스템 설정 따르기"
+      >
+        🖥️
+      </button>
+      
+      <span className="text-sm text-gray-600 dark:text-gray-400">
+        {theme === 'system' ? '시스템' : theme === 'dark' ? '다크' : '라이트'}
+      </span>
+    </div>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,45 +1,41 @@
-'use client'
+"use client";
 
-import { useTheme } from '@/contexts/ThemeContext'
+import { useTheme } from "@/contexts/ThemeContext";
 
 export function ThemeToggle() {
-  const { theme, setTheme, resolvedTheme } = useTheme()
+  const { theme, setTheme, resolvedTheme } = useTheme();
 
   const handleToggle = () => {
-    if (theme === 'system') {
-      setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+    if (theme === "system") {
+      setTheme(resolvedTheme === "dark" ? "light" : "dark");
     } else {
-      setTheme(theme === 'dark' ? 'light' : 'dark')
+      setTheme(theme === "dark" ? "light" : "dark");
     }
-  }
+  };
 
   const handleSystemMode = () => {
-    setTheme('system')
-  }
+    setTheme("system");
+  };
 
   return (
     <div className="flex items-center gap-2">
       <button
         onClick={handleToggle}
         className="p-2 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-800"
-        title={`현재: ${resolvedTheme === 'dark' ? '다크' : '라이트'} 모드`}
+        title={`현재: ${resolvedTheme === "dark" ? "다크" : "라이트"} 모드`}
       >
-        {resolvedTheme === 'dark' ? '🌙' : '☀️'}
+        {resolvedTheme === "dark" ? "🌙" : "☀️"}
       </button>
-      
+
       <button
         onClick={handleSystemMode}
         className={`p-2 rounded-md border hover:bg-gray-100 dark:hover:bg-gray-800 ${
-          theme === 'system' ? 'bg-blue-100 dark:bg-blue-900' : ''
+          theme === "system" ? "bg-blue-100 dark:bg-blue-900" : ""
         }`}
         title="시스템 설정 따르기"
       >
         🖥️
       </button>
-      
-      <span className="text-sm text-gray-600 dark:text-gray-400">
-        {theme === 'system' ? '시스템' : theme === 'dark' ? '다크' : '라이트'}
-      </span>
     </div>
-  )
+  );
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark' | 'system'
+
+interface ThemeContextType {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  resolvedTheme: 'light' | 'dark'
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('system')
+  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') as Theme
+    if (savedTheme) {
+      setTheme(savedTheme)
+    }
+  }, [])
+
+  useEffect(() => {
+    const updateResolvedTheme = () => {
+      if (theme === 'system') {
+        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        setResolvedTheme(systemTheme)
+      } else {
+        setResolvedTheme(theme)
+      }
+    }
+
+    updateResolvedTheme()
+
+    if (theme === 'system') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      mediaQuery.addEventListener('change', updateResolvedTheme)
+      return () => mediaQuery.removeEventListener('change', updateResolvedTheme)
+    }
+  }, [theme])
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (resolvedTheme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+  }, [resolvedTheme])
+
+  const handleSetTheme = (newTheme: Theme) => {
+    setTheme(newTheme)
+    localStorage.setItem('theme', newTheme)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme: handleSetTheme, resolvedTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return context
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,72 +1,93 @@
-'use client'
+"use client";
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = 'light' | 'dark' | 'system'
+type Theme = "light" | "dark" | "system";
 
 interface ThemeContextType {
-  theme: Theme
-  setTheme: (theme: Theme) => void
-  resolvedTheme: 'light' | 'dark'
+  setTheme: (theme: Theme) => void;
+  resolvedTheme: "light" | "dark";
+  theme: Theme;
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const resolveTheme = (theme: Theme) => {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  }
+  return theme;
+};
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('system')
-  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light')
+  const [isSystem, setIsSystem] = useState(true);
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("light");
 
   useEffect(() => {
-    const savedTheme = localStorage.getItem('theme') as Theme
+    const savedTheme = localStorage.getItem("theme") as Theme;
     if (savedTheme) {
-      setTheme(savedTheme)
+      setResolvedTheme(resolveTheme(savedTheme));
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
-    const updateResolvedTheme = () => {
-      if (theme === 'system') {
-        const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-        setResolvedTheme(systemTheme)
-      } else {
-        setResolvedTheme(theme)
-      }
-    }
+    const updateToSystemTheme = () => {
+      setResolvedTheme(
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light",
+      );
+    };
 
-    updateResolvedTheme()
-
-    if (theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-      mediaQuery.addEventListener('change', updateResolvedTheme)
-      return () => mediaQuery.removeEventListener('change', updateResolvedTheme)
+    if (isSystem) {
+      const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+      mediaQuery.addEventListener("change", updateToSystemTheme);
+      return () =>
+        mediaQuery.removeEventListener("change", updateToSystemTheme);
     }
-  }, [theme])
+  }, [isSystem]);
 
   useEffect(() => {
-    const root = document.documentElement
-    if (resolvedTheme === 'dark') {
-      root.classList.add('dark')
+    const root = document.documentElement;
+    if (resolvedTheme === "dark") {
+      root.classList.remove("light");
+      root.classList.add("dark");
     } else {
-      root.classList.remove('dark')
+      root.classList.remove("dark");
+      root.classList.add("light");
     }
-  }, [resolvedTheme])
+  }, [resolvedTheme]);
 
   const handleSetTheme = (newTheme: Theme) => {
-    setTheme(newTheme)
-    localStorage.setItem('theme', newTheme)
-  }
+    if (newTheme === "system") {
+      setIsSystem(true);
+    } else {
+      setIsSystem(false);
+      setResolvedTheme(resolveTheme(newTheme));
+    }
+
+    localStorage.setItem("theme", newTheme);
+  };
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme: handleSetTheme, resolvedTheme }}>
+    <ThemeContext.Provider
+      value={{
+        setTheme: handleSetTheme,
+        resolvedTheme,
+        theme: isSystem ? "system" : resolvedTheme,
+      }}
+    >
       {children}
     </ThemeContext.Provider>
-  )
+  );
 }
 
 export function useTheme() {
-  const context = useContext(ThemeContext)
+  const context = useContext(ThemeContext);
   if (context === undefined) {
-    throw new Error('useTheme must be used within a ThemeProvider')
+    throw new Error("useTheme must be used within a ThemeProvider");
   }
-  return context
+  return context;
 }


### PR DESCRIPTION
## Summary
- 라이트/다크/시스템 테마 전환 기능 구현
- 테마 토글 버튼을 헤더에 추가 
- 사용자 선택한 테마를 localStorage에 저장

## 주요 변경사항
- **ThemeContext**: 테마 상태 관리를 위한 Context API 구현
- **ThemeToggle 컴포넌트**: 테마 전환 UI 컴포넌트 추가
- **CSS 변수**: 라이트/다크 모드별 색상 변수 정의
- **Shiki 코드 하이라이팅**: 테마별 적절한 구문 강조 스타일 적용

## Test plan
- [ ] 라이트 모드 ↔ 다크 모드 전환 확인
- [ ] 시스템 설정 모드 동작 확인
- [ ] 페이지 새로고침 후 테마 유지 확인
- [ ] 코드 블록의 구문 강조가 테마에 맞게 변경되는지 확인
- [ ] 모든 UI 요소가 테마별로 적절히 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)