### PR TITLE
'모든 포스트' 개수 계산 오류 수정

### DIFF
--- a/src/app/PostsList.tsx
+++ b/src/app/PostsList.tsx
@@ -32,6 +32,7 @@ export default function PostsList({ posts, tags, initialTag }: TabViewProps) {
           tagAndCounts={tags}
           selectedTag={selectedTag}
           onTagSelect={setSelectedTag}
+          totalPosts={posts.length}
         />
       </aside>
       <main className={pretendard.className}>

--- a/src/app/TabFilter.tsx
+++ b/src/app/TabFilter.tsx
@@ -4,17 +4,15 @@ interface TabFilterProps {
   tagAndCounts: Record<string, number>;
   selectedTag: string | null;
   onTagSelect: (tag: string | null) => void;
+  totalPosts: number;
 }
 
 export default function TabFilter({
   tagAndCounts,
   selectedTag,
   onTagSelect,
+  totalPosts,
 }: TabFilterProps) {
-  const totalCount = Object.values(tagAndCounts).reduce(
-    (sum, count) => sum + count,
-    0,
-  );
 
   return (
     <nav className="sticky top-6">
@@ -40,7 +38,7 @@ export default function TabFilter({
                 : "text-[var(--color-text-secondary)]"
             }`}
           >
-            {totalCount}
+            {totalPosts}
           </span>
         </button>
 


### PR DESCRIPTION
## Summary
- 태그별 카운트를 합산하여 계산하던 기존 방식에서 실제 포스트 수를 직접 전달하는 방식으로 변경
- 하나의 포스트가 여러 태그를 가질 때 발생하던 중복 계산 문제 해결

## Test plan
- [x] 포스트 목록 페이지에서 '모든 포스트' 옆 숫자가 실제 포스트 개수와 일치하는지 확인
- [x] 각 태그별 포스트 개수가 정확히 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)