### PR TITLE
포스트 목록 날짜순 정렬 및 frontmatter 파싱 개선

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ const fetchAndParsePosts = async (): Promise<Post[]> => {
       githubFile.name.endsWith(".md") || githubFile.name.endsWith(".mdx"),
   );
 
-  return Promise.all(
+  const posts = await Promise.all(
     filteredPostsListData.map(async (post) => {
       const data = await fetchBlogPostsGithubAPI<GetContentsDetailResponse>(
         `/contents/${post.name}`,
@@ -48,6 +48,13 @@ const fetchAndParsePosts = async (): Promise<Post[]> => {
       };
     }),
   );
+
+  // 날짜순으로 정렬 (최신순)
+  return posts.sort((a, b) => {
+    const dateA = new Date(a.frontmatter.date);
+    const dateB = new Date(b.frontmatter.date);
+    return dateB.getTime() - dateA.getTime();
+  });
 };
 
 export default async function Posts({

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -111,6 +111,7 @@ export default async function Post({
             h1: ({ children }) => <h1 className="mt-12">{children}</h1>,
             h2: ({ children }) => <h2 className="mt-10">{children}</h2>,
             h3: ({ children }) => <h3 className="mt-8">{children}</h3>,
+            h4: ({ children }) => <h4 className="mt-6">{children}</h4>,
             img: ({ src, alt, ...props }) => (
               // eslint-disable-next-line @next/next/no-img-element
               <img

--- a/src/utils/__tests__/parseFrontmatter.test.ts
+++ b/src/utils/__tests__/parseFrontmatter.test.ts
@@ -75,6 +75,62 @@ title: "테스트"
 
     expect(() => parseFrontmatter(markdown)).toThrow('Invalid frontmatter')
   })
+
+  it('따옴표 없는 제목을 올바르게 파싱한다', () => {
+    const markdown = `---
+title: React Router loader와 Tanstack Query를 활용한 사용자 상태에 따른 리다이렉트 구현하기
+date: 2025-08-01
+draft: false
+tag:
+- react
+- typescript
+---
+
+내용`
+
+    const result = parseFrontmatter(markdown)
+
+    expect(result.frontmatter.title).toBe('React Router loader와 Tanstack Query를 활용한 사용자 상태에 따른 리다이렉트 구현하기')
+    expect(result.frontmatter.date).toBe('2025-08-01')
+  })
+
+  it('빈 subtitle 값을 올바르게 파싱한다', () => {
+    const markdown = `---
+title: 테스트 제목
+subtitle: 
+date: 2025-08-01
+draft: false
+tag:
+- test
+---
+
+내용`
+
+    const result = parseFrontmatter(markdown)
+
+    expect(result.frontmatter.subtitle).toBe('')
+    expect(result.frontmatter.title).toBe('테스트 제목')
+  })
+
+  it('작은 따옴표와 큰 따옴표가 섞여있어도 올바르게 파싱한다', () => {
+    const markdown = `---
+title: '작은 따옴표 제목'
+subtitle: "큰 따옴표 부제목"
+description: 따옴표 없는 설명
+date: 2025-08-01
+draft: false
+tag:
+- test
+---
+
+내용`
+
+    const result = parseFrontmatter(markdown)
+
+    expect(result.frontmatter.title).toBe('작은 따옴표 제목')
+    expect(result.frontmatter.subtitle).toBe('큰 따옴표 부제목')
+    expect(result.frontmatter.description).toBe('따옴표 없는 설명')
+  })
 })
 
 describe('isValidFrontmatter', () => {

--- a/src/utils/parseFrontmatter.ts
+++ b/src/utils/parseFrontmatter.ts
@@ -20,7 +20,8 @@ export function parseFrontmatter(markdownContent: string): ParseResult {
   // YAML 형태의 frontmatter를 파싱
   const lines = frontmatterStr.split("\n");
 
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     const trimmedLine = line.trim();
     if (!trimmedLine || trimmedLine.startsWith("#")) continue;
 
@@ -41,27 +42,34 @@ export function parseFrontmatter(markdownContent: string): ParseResult {
     const key = trimmedLine.slice(0, colonIndex).trim();
     let value: string | boolean = trimmedLine.slice(colonIndex + 1).trim();
 
-    // 따옴표 제거
-    if (
-      (value.startsWith("'") && value.endsWith("'")) ||
-      (value.startsWith('"') && value.endsWith('"'))
-    ) {
-      value = value.slice(1, -1);
-    }
-
     // 다음 줄이 배열인지 확인
-    const nextLineIndex = lines.indexOf(line) + 1;
     if (
-      nextLineIndex < lines.length &&
-      lines[nextLineIndex].trim().startsWith("-")
+      i + 1 < lines.length &&
+      lines[i + 1].trim().startsWith("-")
     ) {
       frontmatter[key] = [];
     } else {
-      // boolean 값 처리
-      if (value === "true") value = true;
-      else if (value === "false") value = false;
-
-      frontmatter[key] = value;
+      // 빈 값 처리
+      if (value === "") {
+        frontmatter[key] = "";
+      } else {
+        // 따옴표 처리
+        if (
+          (value.startsWith("'") && value.endsWith("'")) ||
+          (value.startsWith('"') && value.endsWith('"'))
+        ) {
+          value = value.slice(1, -1);
+        }
+        
+        // boolean 값 처리
+        if (value === "true") {
+          frontmatter[key] = true;
+        } else if (value === "false") {
+          frontmatter[key] = false;
+        } else {
+          frontmatter[key] = value;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 요약
- 포스트 목록을 최신 날짜순으로 정렬하도록 개선
- Frontmatter 파싱 함수에서 따옴표 없는 값과 빈 값 처리 지원

## 변경사항

### 1. 포스트 목록 정렬 기능 추가
- `src/app/page.tsx`에서 포스트를 날짜 기준 내림차순 정렬
- 최신 포스트가 상단에 표시되도록 개선

### 2. Frontmatter 파싱 함수 개선
- 따옴표 없는 긴 제목 파싱 지원 (예: `title: React Router loader와 Tanstack Query를 활용한...`)
- 빈 값 처리 개선 (예: `subtitle: `)
- 작은 따옴표, 큰 따옴표, 따옴표 없는 값 모두 정상 처리

### 3. 테스트 추가
- 따옴표 없는 제목 파싱 테스트
- 빈 subtitle 값 파싱 테스트
- 다양한 따옴표 형식 혼용 테스트

## 테스트 계획
- [x] 기존 테스트 모두 통과
- [x] 새로 추가한 테스트 케이스 통과
- [ ] 개발 서버에서 포스트 목록 정렬 확인
- [ ] 다양한 frontmatter 형식의 포스트 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)