### PR TITLE
블로그 레이아웃 및 스크롤 동작 개선

### DIFF
--- a/src/app/PostsList.tsx
+++ b/src/app/PostsList.tsx
@@ -20,7 +20,7 @@ export default function PostsList({ posts, tags, initialTag }: TabViewProps) {
     : posts;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[250px_1fr] gap-6 pt-12 pb-24">
+    <div className="grid grid-cols-1 lg:grid-cols-[250px_1fr] gap-6 pt-12 pb-24 px-6">
       <aside className="lg:sticky lg:top-6 lg:h-fit">
         <TabFilter
           tagAndCounts={tags}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,20 +61,6 @@ html.light .shiki span {
   }
 }
 
-@layer components {
-  .container {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding: 0 16px;
-  }
-
-  @media (min-width: 768px) {
-    .container {
-      padding: 0 32px;
-    }
-  }
-}
-
 @layer base {
   h1 {
     @apply scroll-m-20 text-4xl font-extrabold tracking-tight text-balance;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,12 @@ import { ThemeProvider } from "@/contexts/ThemeContext";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { DEFAULT_THEME } from "@/constants/theme";
 import { DOMAIN } from "@/constants/domain";
-import { SITE_NAME, AUTHOR_NAME, SITE_DESCRIPTION, SITE_KEYWORDS } from "@/constants/site";
+import {
+  SITE_NAME,
+  AUTHOR_NAME,
+  SITE_DESCRIPTION,
+  SITE_KEYWORDS,
+} from "@/constants/site";
 
 export const metadata: Metadata = {
   title: {
@@ -73,20 +78,18 @@ export default function RootLayout({
       <head></head>
       <body className={`${pretendard.variable}`}>
         <ThemeProvider>
-          <header className="bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)]">
-            <div className="container flex items-center justify-between h-16">
-              <h1 className="text-xl font-semibold">
-                <Link
-                  href="/"
-                  className="text-[var(--color-text)] hover:text-[var(--color-text)] no-underline hover:underline-0 cursor-pointer"
-                >
-                  {SITE_NAME}
-                </Link>
-              </h1>
-              <ThemeToggle />
-            </div>
+          <header className="bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)] flex items-center justify-between h-16 px-8 fixed top-0 left-0 right-0 z-50">
+            <h1 className="text-xl font-semibold">
+              <Link
+                href="/"
+                className="text-[var(--color-text)] hover:text-[var(--color-text)] no-underline hover:underline-0 cursor-pointer"
+              >
+                {SITE_NAME}
+              </Link>
+            </h1>
+            <ThemeToggle />
           </header>
-          <main className="container">{children}</main>
+          <main className="pt-16">{children}</main>
         </ThemeProvider>
         <Analytics />
       </body>

--- a/src/app/posts/[slug]/(components)/HeadingWithAnchor.tsx
+++ b/src/app/posts/[slug]/(components)/HeadingWithAnchor.tsx
@@ -10,8 +10,8 @@ interface HeadingWithAnchorProps {
   className?: string;
 }
 
-// 헤더(64px) + main 패딩(48px) + 24px
-export const SCROLL_OFFSET = 112;
+// 고정된 헤더(64px) + 여유 공간(16px)
+export const SCROLL_OFFSET = 80;
 
 /**
  * 부모 요소를 자신의 위치로 스크롤 이동. (element.parentElement로 참조)

--- a/src/app/posts/[slug]/(components)/TableOfContents.tsx
+++ b/src/app/posts/[slug]/(components)/TableOfContents.tsx
@@ -157,7 +157,7 @@ export function TableOfContents({ content, className }: TableOfContentsProps) {
   return (
     <>
       {/* 데스크톱 TOC */}
-      <nav className={`hidden lg:block overflow-y-auto py-12 ${className}`}>
+      <nav className={`hidden lg:block ${className}`}>
         <TocList
           headings={headings}
           activeId={activeId}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -12,6 +12,7 @@ import Markdown from "react-markdown";
 import type { Metadata } from "next";
 import { TableOfContents } from "@/app/posts/[slug]/(components)/TableOfContents";
 import { notFound } from "next/navigation";
+import Script from "next/script";
 
 
 const getChildrenCodeTag = (node: ReactNode) => {
@@ -124,8 +125,10 @@ export default async function Post({
   return (
     <>
       <HashScrollHandler />
-      <script
+      <Script
+        id="json-ld"
         type="application/ld+json"
+        strategy="beforeInteractive"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <article className="h-[calc(100vh_-_64px)]">

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -14,7 +14,6 @@ import { TableOfContents } from "@/app/posts/[slug]/(components)/TableOfContents
 import { notFound } from "next/navigation";
 import Script from "next/script";
 
-
 const getChildrenCodeTag = (node: ReactNode) => {
   if (!node || React.Children.count(node) !== 1) return false;
   const child = React.Children.only(node);
@@ -131,66 +130,74 @@ export default async function Post({
         strategy="beforeInteractive"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <article className="h-[calc(100vh_-_64px)]">
-        <div className="grid lg:grid-cols-[1fr_3fr] gap-8 h-full">
-          <TableOfContents content={content} className="py-4" />
-          <div className="py-6 h-full overflow-y-auto lg:col-start-2 pt-12 pb-24">
-            <h1>{frontmatter.title}</h1>
-            <Markdown
-              components={{
-                h1: ({ children }) => (
-                  <HeadingWithAnchor level={1} className="mt-30">
-                    {children}
-                  </HeadingWithAnchor>
-                ),
-                h2: ({ children }) => (
-                  <HeadingWithAnchor level={2} className="mt-24">
-                    {children}
-                  </HeadingWithAnchor>
-                ),
-                h3: ({ children }) => (
-                  <HeadingWithAnchor level={3} className="mt-16">
-                    {children}
-                  </HeadingWithAnchor>
-                ),
-                h4: ({ children }) => (
-                  <HeadingWithAnchor level={4} className="mt-12">
-                    {children}
-                  </HeadingWithAnchor>
-                ),
-                img: ({ src, alt, ...props }) => (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={src}
-                    alt={alt || "블로그 이미지"}
-                    loading="lazy"
-                    {...props}
-                  />
-                ),
-                pre: (props) => {
-                  const codeElement = getChildrenCodeTag(props.children);
-                  if (!codeElement || !isValidCodeElement(codeElement))
-                    return <pre>{props.children}</pre>;
+      <article className="max-w-full">
+        <div className="lg:flex lg:gap-2 relative max-w-full">
+          <TableOfContents
+            content={content}
+            className="py-4 w-[280px] hidden lg:block lg:sticky lg:top-20 lg:overflow-y-auto lg:self-start flex-shrink-0"
+          />
+          <div className="flex-1 py-6 pt-12 pb-24 px-6 min-w-0">
+            <div className="max-w-4xl mx-auto">
+              <h1 className="break-keep">{frontmatter.title}</h1>
+              <Markdown
+                components={{
+                  h1: ({ children }) => (
+                    <HeadingWithAnchor level={1} className="mt-30">
+                      {children}
+                    </HeadingWithAnchor>
+                  ),
+                  h2: ({ children }) => (
+                    <HeadingWithAnchor level={2} className="mt-24">
+                      {children}
+                    </HeadingWithAnchor>
+                  ),
+                  h3: ({ children }) => (
+                    <HeadingWithAnchor level={3} className="mt-16">
+                      {children}
+                    </HeadingWithAnchor>
+                  ),
+                  h4: ({ children }) => (
+                    <HeadingWithAnchor level={4} className="mt-12">
+                      {children}
+                    </HeadingWithAnchor>
+                  ),
+                  img: ({ src, alt, ...props }) => (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={src}
+                      alt={alt || "블로그 이미지"}
+                      loading="lazy"
+                      {...props}
+                    />
+                  ),
+                  pre: (props) => {
+                    const codeElement = getChildrenCodeTag(props.children);
+                    if (!codeElement || !isValidCodeElement(codeElement))
+                      return <pre>{props.children}</pre>;
 
-                  // 타입 가드를 통과했으므로 안전하게 접근 가능
-                  const codeProps = codeElement.props as {
-                    className: string;
-                    children: React.ReactNode;
-                  };
-                  const language = codeProps.className.replace("language-", "");
-
-                  if (language && isSupportedLanguage(language))
-                    return (
-                      <CodeBlock language={language}>
-                        {String(codeProps.children)}
-                      </CodeBlock>
+                    // 타입 가드를 통과했으므로 안전하게 접근 가능
+                    const codeProps = codeElement.props as {
+                      className: string;
+                      children: React.ReactNode;
+                    };
+                    const language = codeProps.className.replace(
+                      "language-",
+                      "",
                     );
-                  else return <pre>{props.children}</pre>;
-                },
-              }}
-            >
-              {content}
-            </Markdown>
+
+                    if (language && isSupportedLanguage(language))
+                      return (
+                        <CodeBlock language={language}>
+                          {String(codeProps.children)}
+                        </CodeBlock>
+                      );
+                    else return <pre>{props.children}</pre>;
+                  },
+                }}
+              >
+                {content}
+              </Markdown>
+            </div>
           </div>
         </div>
       </article>

--- a/src/utils/scrollToElement.ts
+++ b/src/utils/scrollToElement.ts
@@ -2,13 +2,12 @@ import { SCROLL_OFFSET } from "@/app/posts/[slug]/(components)/HeadingWithAnchor
 
 export const scrollToElement = (elementId: string, offset = SCROLL_OFFSET) => {
   const element = document.getElementById(elementId);
-  const parentElement = element?.parentElement;
-  if (!element || !parentElement) return;
+  if (!element) return;
 
   const elementPosition = element.getBoundingClientRect().top;
-  const offsetPosition = elementPosition + parentElement.scrollTop - offset;
+  const offsetPosition = elementPosition + window.scrollY - offset;
 
-  parentElement.scrollTo({
+  window.scrollTo({
     top: offsetPosition,
     behavior: "smooth",
   });


### PR DESCRIPTION
## 요약
- 고정 헤더 구현 및 스크롤 영역 개선
- 포스트 제목 한글 줄바꿈 문제 수정
- JSON-LD 스크립트 최적화

## 변경사항

### 레이아웃 개선
- 헤더를 고정(fixed) 위치로 변경하여 스크롤 시에도 항상 표시
- 메인 콘텐츠에 `pt-16` 추가하여 고정 헤더와 겹치지 않도록 조정
- 불필요한 container 클래스 제거 및 직접 패딩 적용

### 스크롤 동작 개선
- 스크롤 대상을 부모 요소에서 window로 변경하여 전체 페이지 스크롤 지원
- 스크롤 오프셋을 80px로 조정 (헤더 64px + 여유 공간 16px)
- TableOfContents 스티키 위치 조정

### 포스트 페이지 개선
- 포스트 제목에 `break-keep` 적용하여 한글 어절 단위 줄바꿈
- JSON-LD 스크립트를 Next.js Script 컴포넌트로 변경 및 `beforeInteractive` 전략 적용
- 레이아웃을 flexbox로 변경하여 반응형 개선

## 테스트 플랜
- [x] 메인 페이지 레이아웃 확인
- [x] 포스트 페이지 스크롤 동작 확인
- [x] 목차(TOC) 클릭 시 올바른 위치로 이동하는지 확인
- [x] 긴 제목의 한글 줄바꿈이 어절 단위로 되는지 확인
- [x] 모바일/데스크톱 반응형 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.ai/code)