### PR TITLE
feat: GitHub 포스트 경로를 posts 디렉토리로 변경

### DIFF
--- a/src/utils/githubBlogPost.ts
+++ b/src/utils/githubBlogPost.ts
@@ -27,7 +27,7 @@ const isMarkdownFile = (fileName: string): boolean => {
  * 블로그 포스트 목록을 가져와서 처리
  */
 export async function fetchBlogPosts(
-  options: FetchPostsOptions = {}
+  options: FetchPostsOptions = {},
 ): Promise<BlogPost[]> {
   const {
     includeDrafts = false,
@@ -37,11 +37,11 @@ export async function fetchBlogPosts(
 
   // GitHub에서 파일 목록 가져오기
   const postsListData =
-    await fetchBlogPostsGithubAPI<GetContentsResponse[]>("/contents");
+    await fetchBlogPostsGithubAPI<GetContentsResponse[]>("/contents/posts");
 
   // 마크다운 파일만 필터링
   const markdownFiles = postsListData.filter((file) =>
-    isMarkdownFile(file.name)
+    isMarkdownFile(file.name),
   );
 
   // 각 파일의 상세 정보 가져오기
@@ -49,7 +49,7 @@ export async function fetchBlogPosts(
     markdownFiles.map(async (file) => {
       const postData = await fetchSingleBlogPost(file.name, includeContent);
       return postData;
-    })
+    }),
   );
 
   // draft 필터링
@@ -74,10 +74,10 @@ export async function fetchBlogPosts(
  */
 export async function fetchSingleBlogPost(
   fileName: string,
-  includeContent = true
+  includeContent = true,
 ): Promise<BlogPost> {
   const data = await fetchBlogPostsGithubAPI<GetContentsDetailData>(
-    `/contents/${fileName}`
+    `/contents/posts/${fileName}`,
   );
 
   const decodedContent = decodeBase64Content(data.content);


### PR DESCRIPTION
## 요약
- GitHub API에서 블로그 포스트를 가져올 때 사용하는 경로를 변경했습니다
- 리포지토리 루트(`/contents`) → posts 디렉토리(`/contents/posts`)로 변경

## 변경 사항
- `fetchBlogPosts` 함수: `/contents` → `/contents/posts`
- `fetchSingleBlogPost` 함수: `/contents/${fileName}` → `/contents/posts/${fileName}`

## 테스트 계획
- [ ] 블로그 포스트 목록이 정상적으로 로드되는지 확인
- [ ] 개별 포스트 페이지가 정상적으로 렌더링되는지 확인
- [ ] GitHub API 호출이 올바른 경로로 이루어지는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)