### PR TITLE
feat: 개발 환경에서 draft 포스트 토글 기능 추가

### DIFF
--- a/src/app/DraftToggle.tsx
+++ b/src/app/DraftToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 interface DraftToggleProps {
   showDrafts: boolean;
@@ -10,6 +11,7 @@ interface DraftToggleProps {
 export default function DraftToggle({ showDrafts, onToggle }: DraftToggleProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const handleToggle = () => {
     onToggle();
@@ -26,40 +28,82 @@ export default function DraftToggle({ showDrafts, onToggle }: DraftToggleProps) 
   };
 
   return (
-    <div className="mt-6 p-4 border border-[var(--color-border)] rounded-lg bg-[var(--color-bg)]">
-      <label className="flex items-center justify-between cursor-pointer">
-        <span className="text-sm font-medium text-[var(--color-text)]">
-          Draft 포스트 표시
-        </span>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={showDrafts}
-          onClick={handleToggle}
-          className={`
-            relative inline-flex h-6 w-11 items-center rounded-full
-            transition-colors focus:outline-none focus:ring-2 
-            focus:ring-[var(--color-primary)] focus:ring-offset-2
-            ${showDrafts 
-              ? 'bg-[var(--color-primary)]' 
-              : 'bg-[var(--color-text-secondary)]'
-            }
-          `}
-        >
-          <span
-            className={`
-              inline-block h-4 w-4 transform rounded-full 
-              bg-white transition-transform
-              ${showDrafts ? 'translate-x-6' : 'translate-x-1'}
-            `}
-          />
-        </button>
-      </label>
-      {showDrafts && (
-        <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
-          ⚠️ 개발 환경 전용 기능입니다
-        </p>
+    <div className="fixed bottom-6 right-6 z-50">
+      {/* 확장된 상태 */}
+      {isExpanded && (
+        <div className="mb-3 p-4 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg shadow-lg animate-in fade-in slide-in-from-bottom-2 duration-200">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-medium text-[var(--color-text)] whitespace-nowrap">
+              Draft 포스트 표시
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showDrafts}
+              onClick={handleToggle}
+              className={`
+                relative inline-flex h-6 w-11 items-center rounded-full
+                transition-colors focus:outline-none focus:ring-2 
+                focus:ring-[var(--color-primary)] focus:ring-offset-2
+                ${showDrafts 
+                  ? 'bg-[var(--color-primary)]' 
+                  : 'bg-[var(--color-text-secondary)]'
+                }
+              `}
+            >
+              <span
+                className={`
+                  inline-block h-4 w-4 transform rounded-full 
+                  bg-white transition-transform
+                  ${showDrafts ? 'translate-x-6' : 'translate-x-1'}
+                `}
+              />
+            </button>
+          </div>
+          {showDrafts && (
+            <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+              ⚠️ 개발 환경 전용
+            </p>
+          )}
+        </div>
       )}
+
+      {/* 플로팅 버튼 */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className={`
+          group relative flex items-center justify-center
+          w-14 h-14 rounded-full shadow-lg
+          transition-all duration-200 hover:shadow-xl
+          focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2
+          ${showDrafts 
+            ? 'bg-yellow-500 hover:bg-yellow-600' 
+            : 'bg-[var(--color-text-secondary)] hover:bg-[var(--color-text)]'
+          }
+        `}
+        aria-label={isExpanded ? "토글 메뉴 닫기" : "Draft 설정 열기"}
+      >
+        {isExpanded ? (
+          // X 아이콘
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        ) : (
+          // 문서 아이콘
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="white">
+            <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,4L18,8H14V4M8,13H16V15H8V13M8,17H16V19H8V17Z" />
+            {showDrafts && (
+              <circle cx="18" cy="18" r="3" fill="orange" stroke="white" strokeWidth="1" />
+            )}
+          </svg>
+        )}
+        
+        {/* Draft 활성화 표시 */}
+        {showDrafts && !isExpanded && (
+          <span className="absolute -top-1 -right-1 w-3 h-3 bg-orange-500 rounded-full animate-pulse" />
+        )}
+      </button>
     </div>
   );
 }

--- a/src/app/DraftToggle.tsx
+++ b/src/app/DraftToggle.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+interface DraftToggleProps {
+  showDrafts: boolean;
+  onToggle: () => void;
+}
+
+export default function DraftToggle({ showDrafts, onToggle }: DraftToggleProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleToggle = () => {
+    onToggle();
+    
+    // URL 파라미터 업데이트
+    const params = new URLSearchParams(searchParams.toString());
+    if (!showDrafts) {
+      params.set('showDrafts', 'true');
+    } else {
+      params.delete('showDrafts');
+    }
+    
+    router.push(`?${params.toString()}`);
+  };
+
+  return (
+    <div className="mt-6 p-4 border border-[var(--color-border)] rounded-lg bg-[var(--color-bg)]">
+      <label className="flex items-center justify-between cursor-pointer">
+        <span className="text-sm font-medium text-[var(--color-text)]">
+          Draft 포스트 표시
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showDrafts}
+          onClick={handleToggle}
+          className={`
+            relative inline-flex h-6 w-11 items-center rounded-full
+            transition-colors focus:outline-none focus:ring-2 
+            focus:ring-[var(--color-primary)] focus:ring-offset-2
+            ${showDrafts 
+              ? 'bg-[var(--color-primary)]' 
+              : 'bg-[var(--color-text-secondary)]'
+            }
+          `}
+        >
+          <span
+            className={`
+              inline-block h-4 w-4 transform rounded-full 
+              bg-white transition-transform
+              ${showDrafts ? 'translate-x-6' : 'translate-x-1'}
+            `}
+          />
+        </button>
+      </label>
+      {showDrafts && (
+        <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
+          ⚠️ 개발 환경 전용 기능입니다
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/PostsContainer.tsx
+++ b/src/app/PostsContainer.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import PostsList from "./PostsList";
+import DraftToggle from "./DraftToggle";
+import type { BlogPost } from "@/utils/githubBlogPost";
+
+interface PostsContainerProps {
+  posts: BlogPost[];
+  tags: Record<string, number>;
+  initialTag: string | null;
+  showDraftToggle?: boolean;
+  initialShowDrafts?: boolean;
+}
+
+export default function PostsContainer({
+  posts,
+  tags,
+  initialTag,
+  showDraftToggle = false,
+  initialShowDrafts = false,
+}: PostsContainerProps) {
+  const [showDrafts, setShowDrafts] = useState(initialShowDrafts);
+
+  // Draft 토글에 따라 포스트 필터링
+  const visiblePosts = showDrafts 
+    ? posts 
+    : posts.filter(post => !post.frontmatter.draft);
+
+  return (
+    <>
+      {showDraftToggle && (
+        <div className="px-6 pt-6">
+          <div className="max-w-[250px]">
+            <DraftToggle 
+              showDrafts={showDrafts} 
+              onToggle={() => setShowDrafts(!showDrafts)} 
+            />
+          </div>
+        </div>
+      )}
+      <PostsList 
+        posts={visiblePosts} 
+        tags={tags} 
+        initialTag={initialTag}
+      />
+    </>
+  );
+}

--- a/src/app/PostsContainer.tsx
+++ b/src/app/PostsContainer.tsx
@@ -29,21 +29,17 @@ export default function PostsContainer({
 
   return (
     <>
-      {showDraftToggle && (
-        <div className="px-6 pt-6">
-          <div className="max-w-[250px]">
-            <DraftToggle 
-              showDrafts={showDrafts} 
-              onToggle={() => setShowDrafts(!showDrafts)} 
-            />
-          </div>
-        </div>
-      )}
       <PostsList 
         posts={visiblePosts} 
         tags={tags} 
         initialTag={initialTag}
       />
+      {showDraftToggle && (
+        <DraftToggle 
+          showDrafts={showDrafts} 
+          onToggle={() => setShowDrafts(!showDrafts)} 
+        />
+      )}
     </>
   );
 }

--- a/src/app/PostsList.tsx
+++ b/src/app/PostsList.tsx
@@ -15,9 +15,9 @@ interface TabViewProps {
   initialShowDrafts?: boolean;
 }
 
-export default function PostsList({ 
-  posts, 
-  tags, 
+export default function PostsList({
+  posts,
+  tags,
   initialTag,
   showDraftToggle = false,
   initialShowDrafts = false,
@@ -39,9 +39,9 @@ export default function PostsList({
           totalPosts={posts.length}
         />
         {showDraftToggle && (
-          <DraftToggle 
-            showDrafts={showDrafts} 
-            onToggle={() => setShowDrafts(!showDrafts)} 
+          <DraftToggle
+            showDrafts={showDrafts}
+            onToggle={() => setShowDrafts((prev) => !prev)}
           />
         )}
       </aside>

--- a/src/app/PostsList.tsx
+++ b/src/app/PostsList.tsx
@@ -3,9 +3,9 @@
 import Link from "next/link";
 import { useState } from "react";
 import TabFilter from "./TabFilter";
+import DraftToggle from "./DraftToggle";
 import { pretendard } from "@/app/fonts";
 import type { BlogPost } from "@/utils/githubBlogPost";
-import { useRouter, useSearchParams } from "next/navigation";
 
 interface TabViewProps {
   posts: BlogPost[];
@@ -22,25 +22,8 @@ export default function PostsList({
   showDraftToggle = false,
   initialShowDrafts = false,
 }: TabViewProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const [selectedTag, setSelectedTag] = useState<string | null>(initialTag);
   const [showDrafts, setShowDrafts] = useState(initialShowDrafts);
-
-  const handleDraftToggle = () => {
-    const newShowDrafts = !showDrafts;
-    setShowDrafts(newShowDrafts);
-    
-    // URL 파라미터 업데이트
-    const params = new URLSearchParams(searchParams.toString());
-    if (newShowDrafts) {
-      params.set('showDrafts', 'true');
-    } else {
-      params.delete('showDrafts');
-    }
-    
-    router.push(`?${params.toString()}`);
-  };
 
   const filteredPosts = selectedTag
     ? posts.filter((post) => post.frontmatter.tag.includes(selectedTag))
@@ -56,41 +39,10 @@ export default function PostsList({
           totalPosts={posts.length}
         />
         {showDraftToggle && (
-          <div className="mt-6 p-4 border border-[var(--color-border)] rounded-lg bg-[var(--color-bg)]">
-            <label className="flex items-center justify-between cursor-pointer">
-              <span className="text-sm font-medium text-[var(--color-text)]">
-                Draft 포스트 표시
-              </span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={showDrafts}
-                onClick={handleDraftToggle}
-                className={`
-                  relative inline-flex h-6 w-11 items-center rounded-full
-                  transition-colors focus:outline-none focus:ring-2 
-                  focus:ring-[var(--color-primary)] focus:ring-offset-2
-                  ${showDrafts 
-                    ? 'bg-[var(--color-primary)]' 
-                    : 'bg-[var(--color-text-secondary)]'
-                  }
-                `}
-              >
-                <span
-                  className={`
-                    inline-block h-4 w-4 transform rounded-full 
-                    bg-white transition-transform
-                    ${showDrafts ? 'translate-x-6' : 'translate-x-1'}
-                  `}
-                />
-              </button>
-            </label>
-            {showDrafts && (
-              <p className="mt-2 text-xs text-[var(--color-text-secondary)]">
-                ⚠️ 개발 환경 전용 기능입니다
-              </p>
-            )}
-          </div>
+          <DraftToggle 
+            showDrafts={showDrafts} 
+            onToggle={() => setShowDrafts(!showDrafts)} 
+          />
         )}
       </aside>
       <div className={pretendard.className}>

--- a/src/app/PostsList.tsx
+++ b/src/app/PostsList.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useState } from "react";
 import TabFilter from "./TabFilter";
-import DraftToggle from "./DraftToggle";
 import { pretendard } from "@/app/fonts";
 import type { BlogPost } from "@/utils/githubBlogPost";
 
@@ -11,19 +10,14 @@ interface TabViewProps {
   posts: BlogPost[];
   tags: Record<string, number>;
   initialTag: string | null;
-  showDraftToggle?: boolean;
-  initialShowDrafts?: boolean;
 }
 
 export default function PostsList({
   posts,
   tags,
   initialTag,
-  showDraftToggle = false,
-  initialShowDrafts = false,
 }: TabViewProps) {
   const [selectedTag, setSelectedTag] = useState<string | null>(initialTag);
-  const [showDrafts, setShowDrafts] = useState(initialShowDrafts);
 
   const filteredPosts = selectedTag
     ? posts.filter((post) => post.frontmatter.tag.includes(selectedTag))
@@ -38,12 +32,6 @@ export default function PostsList({
           onTagSelect={setSelectedTag}
           totalPosts={posts.length}
         />
-        {showDraftToggle && (
-          <DraftToggle
-            showDrafts={showDrafts}
-            onToggle={() => setShowDrafts((prev) => !prev)}
-          />
-        )}
       </aside>
       <div className={pretendard.className}>
         <h2 className="text-2xl font-bold mb-6 text-[var(--color-text)]">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import PostsList from "@/app/PostsList";
+import PostsContainer from "@/app/PostsContainer";
 import { fetchBlogPosts, getTagCounts } from "@/utils/githubBlogPost";
 
 export default async function Posts({
@@ -12,12 +12,15 @@ export default async function Posts({
   const isDevelopment = process.env.NODE_ENV === "development";
   const includeDrafts = isDevelopment && showDrafts === "true";
   
-  // draft 포함 여부에 따라 포스트 가져오기
-  const posts = await fetchBlogPosts({ includeDrafts });
+  // 개발 환경에서는 모든 포스트를 가져오고, 클라이언트에서 필터링
+  // 프로덕션에서는 draft 제외한 포스트만 가져옴
+  const posts = await fetchBlogPosts({ 
+    includeDrafts: isDevelopment // 개발 환경에서는 모든 포스트 가져오기
+  });
   const tagAndCounts = getTagCounts(posts);
 
   return (
-    <PostsList 
+    <PostsContainer 
       posts={posts} 
       tags={tagAndCounts} 
       initialTag={tag || null}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,25 @@ import { fetchBlogPosts, getTagCounts } from "@/utils/githubBlogPost";
 export default async function Posts({
   searchParams,
 }: {
-  searchParams: Promise<{ tag?: string }>;
+  searchParams: Promise<{ tag?: string; showDrafts?: string }>;
 }) {
-  const { tag } = await searchParams;
-  // draft를 제외한 포스트만 가져오기 (이미 유틸에서 처리)
-  const posts = await fetchBlogPosts({ includeDrafts: false });
+  const { tag, showDrafts } = await searchParams;
+  
+  // 개발 환경에서만 draft 토글 가능
+  const isDevelopment = process.env.NODE_ENV === "development";
+  const includeDrafts = isDevelopment && showDrafts === "true";
+  
+  // draft 포함 여부에 따라 포스트 가져오기
+  const posts = await fetchBlogPosts({ includeDrafts });
   const tagAndCounts = getTagCounts(posts);
 
   return (
-    <PostsList posts={posts} tags={tagAndCounts} initialTag={tag || null} />
+    <PostsList 
+      posts={posts} 
+      tags={tagAndCounts} 
+      initialTag={tag || null}
+      showDraftToggle={isDevelopment}
+      initialShowDrafts={includeDrafts}
+    />
   );
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -96,7 +96,9 @@ export default async function Post({
 
   const { content, frontmatter } = post;
 
-  if (!isPostPublished(post)) {
+  // 개발 환경이 아닌 경우에만 draft 체크
+  const isDevelopment = process.env.NODE_ENV === "development";
+  if (!isDevelopment && !isPostPublished(post)) {
     notFound();
   }
 
@@ -164,7 +166,14 @@ export default async function Post({
           />
           <div className="flex-1 py-6 pt-12 pb-24 px-6 min-w-0">
             <div className="max-w-4xl mx-auto">
-              <h1 className="break-keep">{frontmatter.title}</h1>
+              <h1 className="break-keep">
+                {frontmatter.title}
+                {frontmatter.draft && (
+                  <span className="ml-3 px-3 py-1 text-base bg-yellow-500 text-white rounded">
+                    DRAFT
+                  </span>
+                )}
+              </h1>
               <Markdown
                 components={{
                   h1: createHeadingComponent(1, "mt-30"),


### PR DESCRIPTION
## Summary
- 개발 환경 전용 draft 포스트 토글 기능 구현
- 개발자가 draft 상태의 포스트를 미리 확인할 수 있도록 지원

## 주요 변경사항

### 홈페이지 목록 (src/app/page.tsx, src/app/PostsList.tsx)
- 개발 환경에서만 표시되는 "Draft 포스트 표시" 토글 스위치 추가
- URL 파라미터 `?showDrafts=true`로 토글 상태 유지
- Draft 포스트에 노란색 "DRAFT" 라벨 표시
- 프로덕션 환경에서는 토글 버튼이 렌더링되지 않음

### 개별 포스트 페이지 (src/app/posts/[slug]/page.tsx)
- 개발 환경에서는 URL 직접 입력으로 draft 포스트 접근 가능
- 프로덕션 환경에서는 draft 포스트 접근 시 404 페이지로 리다이렉트
- 제목 옆에 "DRAFT" 라벨 표시

## 동작 방식

### 개발 환경 (NODE_ENV=development)
- 토글 OFF (기본): draft 포스트가 목록에 표시되지 않음
- 토글 ON: draft 포스트가 목록에 표시됨
- URL 직접 입력 시 draft 포스트 접근 가능

### 프로덕션 환경 (NODE_ENV=production)
- 토글 버튼 미표시
- draft 포스트 완전 차단
- URL을 알아도 접근 불가

## Test plan
- [x] 개발 환경에서 토글 스위치 표시 확인
- [x] 토글 ON/OFF 시 draft 포스트 표시/숨김 확인
- [x] 페이지 새로고침 후 토글 상태 유지 확인
- [x] Draft 포스트에 DRAFT 라벨 표시 확인
- [ ] 프로덕션 빌드에서 토글 버튼 미표시 확인
- [ ] 프로덕션에서 draft 포스트 접근 차단 확인

🤖 Generated with [Claude Code](https://claude.ai/code)