### PR TITLE
중첩된 리스트 스타일 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,11 +104,24 @@ html.light .shiki span {
   p {
     @apply leading-7 [&:not(:first-child)]:mt-6;
   }
-  ul {
+  /* 최상위 리스트에만 스타일 적용 */
+  ul:not(li > ul) {
     @apply my-6 ml-6 list-disc [&>li]:mt-2;
   }
-  ol {
+  
+  /* 중첩된 ul은 기본 스타일만 적용 */
+  li > ul {
+    @apply ml-6 list-disc mt-2;
+  }
+  
+  /* 최상위 ol에만 스타일 적용 */
+  ol:not(li > ol) {
     @apply my-6 ml-6 list-decimal [&>li]:mt-2;
+  }
+  
+  /* 중첩된 ol은 기본 스타일만 적용 */
+  li > ol {
+    @apply ml-6 list-decimal mt-2;
   }
   
   blockquote {


### PR DESCRIPTION
## 개요
중첩된 ul/ol 리스트에 과도한 여백이 적용되는 문제를 수정했습니다.

## 문제점
- 중첩된 리스트(ul 안의 ul, ol 안의 ol)에도 최상위 리스트와 동일한 큰 여백(my-6)이 적용되어 불필요한 공간이 생김

## 해결 방법
CSS 선택자를 사용하여 최상위 리스트와 중첩된 리스트를 구분:
- `ul:not(li > ul)`: 최상위 ul에만 큰 여백 적용
- `li > ul`: 중첩된 ul은 작은 여백만 적용
- ol도 동일한 방식으로 처리

## 변경 사항
```css
/* 최상위 리스트 */
- 상하 여백: my-6 (1.5rem)
- 들여쓰기: ml-6
- 항목 간격: mt-2

/* 중첩된 리스트 */  
- 상단 여백: mt-2 (0.5rem)
- 들여쓰기: ml-6
```

## 테스트
- [x] 최상위 ul/ol 스타일 확인
- [x] 중첩된 ul/ol 스타일 확인
- [x] 다크모드에서 동작 확인

🤖 Generated with [Claude Code](https://claude.ai/code)