### PR TITLE
MDEditor에 다크/라이트 테마 지원 추가

### DIFF
--- a/src/app/admin/posts/[slug]/edit/page.tsx
+++ b/src/app/admin/posts/[slug]/edit/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { Loader2 } from "lucide-react";
 import { generateFrontmatter } from "@/utils/frontmatter";
+import { useTheme } from "@/contexts/ThemeContext";
 
 const MDEditor = dynamic(
   () => import("@uiw/react-md-editor").then((mod) => mod.default),
@@ -24,6 +25,7 @@ export default function EditPostPage() {
   const router = useRouter();
   const params = useParams();
   const slug = params.slug as string;
+  const { theme } = useTheme();
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -204,13 +206,15 @@ export default function EditPostPage() {
 
         <div>
           <label className="block text-sm font-medium mb-2">내용 *</label>
-          <div data-color-mode="light" className="min-h-[500px]">
-            <MDEditor
-              value={form.content}
-              onChange={(value) => setForm({ ...form, content: value || "" })}
-              preview="live"
-              height={500}
-            />
+          <div data-color-mode={theme} className="min-h-[500px]">
+            <div className="wmde-markdown-var">
+              <MDEditor
+                value={form.content}
+                onChange={(value) => setForm({ ...form, content: value || "" })}
+                preview="live"
+                height={500}
+              />
+            </div>
           </div>
         </div>
 

--- a/src/app/admin/posts/new/page.tsx
+++ b/src/app/admin/posts/new/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { Loader2 } from "lucide-react";
 import { generateFrontmatter } from "@/utils/frontmatter";
+import { useTheme } from "@/contexts/ThemeContext";
 
 const MDEditor = dynamic(
   () => import("@uiw/react-md-editor").then((mod) => mod.default),
@@ -21,6 +22,7 @@ interface PostForm {
 
 export default function NewPostPage() {
   const router = useRouter();
+  const { theme } = useTheme();
   const [loading, setLoading] = useState(false);
   const [form, setForm] = useState<PostForm>({
     title: "",
@@ -152,13 +154,15 @@ export default function NewPostPage() {
 
         <div>
           <label className="block text-sm font-medium mb-2">내용 *</label>
-          <div data-color-mode="light" className="min-h-[500px]">
-            <MDEditor
-              value={form.content}
-              onChange={(value) => setForm({ ...form, content: value || "" })}
-              preview="live"
-              height={500}
-            />
+          <div data-color-mode={theme} className="min-h-[500px]">
+            <div className="wmde-markdown-var">
+              <MDEditor
+                value={form.content}
+                onChange={(value) => setForm({ ...form, content: value || "" })}
+                preview="live"
+                height={500}
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## 요약
- MDEditor 컴포넌트에 다크/라이트 테마 자동 전환 기능 추가
- 사용자가 선택한 테마에 따라 에디터 색상 모드가 동적으로 변경됨

## 변경사항
### 수정된 파일
- `src/app/admin/posts/new/page.tsx`: 새 포스트 작성 페이지
- `src/app/admin/posts/[slug]/edit/page.tsx`: 포스트 편집 페이지

### 구현 내용
1. **ThemeContext 연동**
   - `useTheme` hook을 import하여 현재 테마 상태 가져오기
   - 컴포넌트에서 `const { theme } = useTheme()` 사용

2. **동적 테마 적용**
   - `data-color-mode` 속성을 하드코딩된 `"light"`에서 동적 `theme` 값으로 변경
   - 현재 테마에 따라 "light" 또는 "dark" 모드 자동 적용

3. **스타일 상속 개선**
   - `wmde-markdown-var` 클래스를 가진 wrapper div 추가
   - MDEditor 라이브러리 문서에서 권장하는 방식으로 커스텀 색상 변수 상속 지원

## 테스트 계획
- [ ] 라이트 모드에서 MDEditor가 올바르게 표시되는지 확인
- [ ] 다크 모드로 전환 시 MDEditor 색상이 자동으로 변경되는지 확인
- [ ] 새 포스트 작성 페이지에서 테마 전환 테스트
- [ ] 포스트 편집 페이지에서 테마 전환 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)